### PR TITLE
feat: add editing and management controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
                                 <h4>Доходы</h4>
                                 <span class="stat-value">85,000 ₽</span>
                             </div>
+                            <button class="btn btn--secondary btn--sm stat-edit" onclick="app.editIncome()">✏️</button>
                         </div>
                         <div class="stat-card expense">
                             <div class="stat-icon">📉</div>
@@ -90,6 +91,7 @@
                                 <h4>Расходы</h4>
                                 <span class="stat-value">85,000 ₽</span>
                             </div>
+                            <button class="btn btn--secondary btn--sm stat-edit" onclick="app.editExpenses()">✏️</button>
                         </div>
                         <div class="stat-card savings">
                             <div class="stat-icon">💰</div>
@@ -97,6 +99,7 @@
                                 <h4>Накопления</h4>
                                 <span class="stat-value">5,000 ₽</span>
                             </div>
+                            <button class="btn btn--secondary btn--sm stat-edit" onclick="app.editSavings()">✏️</button>
                         </div>
                     </div>
 

--- a/style.css
+++ b/style.css
@@ -997,6 +997,10 @@ select.form-control {
   transition: all var(--duration-normal) var(--ease-standard);
 }
 
+.stat-edit {
+  margin-left: auto;
+}
+
 .stat-card:hover {
   transform: translateY(-2px);
   box-shadow: var(--shadow-lg);
@@ -1072,6 +1076,12 @@ select.form-control {
   font-size: var(--font-size-sm);
   color: var(--color-primary);
   font-weight: var(--font-weight-medium);
+}
+
+.goal-actions {
+  display: flex;
+  gap: var(--space-8);
+  margin-top: var(--space-16);
 }
 
 /* Progress Bar */
@@ -1207,6 +1217,17 @@ select.form-control {
   justify-content: space-between;
   align-items: center;
   transition: all var(--duration-normal) var(--ease-standard);
+}
+
+.transaction-meta-container {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+}
+
+.transaction-actions {
+  display: flex;
+  gap: var(--space-8);
 }
 
 .transaction-card:hover {


### PR DESCRIPTION
## Summary
- add dashboard edit buttons for income, expenses, and savings
- enable editing and deleting transactions and goals
- allow updating goal progress and budget figures

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a44be71cc8832295f92b039c3ca7a5