### PR TITLE
feat: sync counter with dashboard totals

### DIFF
--- a/app.js
+++ b/app.js
@@ -895,8 +895,10 @@ class BudgetApp {
         const balanceContainer = document.getElementById('counterBalanceContainer');
         if (!balanceEl || !incomeEl || !expenseEl || !balanceContainer) return;
 
-        const totalIncome = this.data.monthlyBudget.income.salary + this.data.monthlyBudget.income.freelance;
-        const totalExpenses = Object.values(this.data.monthlyBudget.expenses).reduce((sum, exp) => sum + exp.actual, 0);
+        const totalIncome = Object.values(this.data.monthlyBudget.income)
+            .reduce((sum, inc) => sum + inc, 0);
+        const totalExpenses = Object.values(this.data.monthlyBudget.expenses)
+            .reduce((sum, exp) => sum + exp.actual, 0);
         const net = totalIncome - totalExpenses;
 
         incomeEl.textContent = this.formatCurrency(totalIncome);
@@ -907,17 +909,23 @@ class BudgetApp {
             this.counterInterval = null;
         }
 
-        this.counterValue = net;
+        this.counterValue = 0;
         balanceEl.textContent = this.formatCurrency(this.counterValue);
         balanceContainer.classList.toggle('negative', this.counterValue < 0);
         balanceContainer.classList.toggle('positive', this.counterValue >= 0);
 
         if (net !== 0) {
+            const step = net > 0 ? 1 : -1;
             this.counterInterval = setInterval(() => {
-                this.counterValue += net > 0 ? 1 : -1;
+                this.counterValue += step;
                 balanceEl.textContent = this.formatCurrency(this.counterValue);
                 balanceContainer.classList.toggle('negative', this.counterValue < 0);
                 balanceContainer.classList.toggle('positive', this.counterValue >= 0);
+
+                if (this.counterValue === net) {
+                    clearInterval(this.counterInterval);
+                    this.counterInterval = null;
+                }
             }, 1000);
         }
     }

--- a/index.html
+++ b/index.html
@@ -236,23 +236,6 @@
                         <div class="counter-balance" id="counterBalanceContainer">
                             <span id="counterBalanceValue">0</span> ₽
                         </div>
-                        <div class="counter-controls">
-                            <div class="form-group">
-                                <label class="form-label">Начальный баланс</label>
-                                <input type="number" class="form-control" id="initialBalanceInput" placeholder="0">
-                                <button class="btn btn--secondary" id="setInitialBalanceBtn">Установить</button>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">Доход</label>
-                                <input type="number" class="form-control" id="incomeInput" placeholder="0">
-                                <button class="btn btn--primary" id="addIncomeBtn">Добавить</button>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">Расход</label>
-                                <input type="number" class="form-control" id="expenseInput" placeholder="0">
-                                <button class="btn btn--primary" id="addExpenseBtn">Добавить</button>
-                            </div>
-                        </div>
                         <div class="counter-summary">
                             Доходы: <span id="counterIncomeTotal">0</span> ₽ | Расходы: <span id="counterExpenseTotal">0</span> ₽
                         </div>

--- a/style.css
+++ b/style.css
@@ -1532,17 +1532,20 @@ select.form-control {
 }
 
 /* Counter styles */
-.counter-card .form-group {
-  display: flex;
-  align-items: center;
-  gap: var(--space-8);
-  margin-bottom: var(--space-16);
-}
-
 .counter-balance {
-  font-size: 2rem;
+  font-size: 2.5rem;
   font-weight: bold;
   margin-bottom: var(--space-16);
+  padding: var(--space-16);
+  text-align: center;
+  border-radius: var(--radius-8);
+  background: var(--color-surface-2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: color 0.3s ease;
+}
+
+.counter-balance.positive {
+  color: var(--color-green-500);
 }
 
 .counter-balance.negative {


### PR DESCRIPTION
## Summary
- Remove manual money input controls and display dashboard income and expense totals in the counter section
- Style balance indicator and colorize positive/negative values
- Animate counter balance increasing or decreasing each second based on net flow

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a451b34254832292e0b5e71c829338