### PR TITLE
Fix dashboard stats computation without counter data

### DIFF
--- a/app.js
+++ b/app.js
@@ -491,9 +491,11 @@ class BudgetApp {
     }
 
     updateStats() {
-        const totalIncome = Object.values(this.data.monthlyBudget.income).reduce((sum, val) => sum + val, 0);
-        const totalExpenses = Object.values(this.data.monthlyBudget.expenses).reduce((sum, exp) => sum + exp.actual, 0);
-        const balance = this.counterData.balance;
+        const totalIncome = Object.values(this.data.monthlyBudget.income)
+            .reduce((sum, val) => sum + val, 0);
+        const totalExpenses = Object.values(this.data.monthlyBudget.expenses)
+            .reduce((sum, exp) => sum + exp.actual, 0);
+        const balance = totalIncome - totalExpenses;
 
         const totalBalanceEl = document.getElementById('totalBalance');
         if (totalBalanceEl) {


### PR DESCRIPTION
## Summary
- avoid accessing undefined counterData in `updateStats`
- compute balance from income and expenses directly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4606c1a6c83228ccea18a67676a1b