### PR TITLE
feat: manage income categories

### DIFF
--- a/app.js
+++ b/app.js
@@ -245,12 +245,38 @@ class BudgetApp {
             });
         }
 
+        // Income list modal
+        const closeIncomeListModal = document.getElementById('closeIncomeListModal');
+        if (closeIncomeListModal) {
+            closeIncomeListModal.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.hideModal('incomeListModal');
+            });
+        }
+
+        const cancelIncomeList = document.getElementById('cancelIncomeList');
+        if (cancelIncomeList) {
+            cancelIncomeList.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.hideModal('incomeListModal');
+            });
+        }
+
+        const addIncomeBtn = document.getElementById('addIncome');
+        if (addIncomeBtn) {
+            addIncomeBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.showIncomeEditForm();
+            });
+        }
+
         // Income modal
         const closeIncomeModal = document.getElementById('closeIncomeModal');
         if (closeIncomeModal) {
             closeIncomeModal.addEventListener('click', (e) => {
                 e.preventDefault();
                 this.hideModal('incomeModal');
+                this.showModal('incomeListModal');
             });
         }
 
@@ -259,6 +285,7 @@ class BudgetApp {
             cancelIncome.addEventListener('click', (e) => {
                 e.preventDefault();
                 this.hideModal('incomeModal');
+                this.showModal('incomeListModal');
             });
         }
 
@@ -1147,8 +1174,63 @@ class BudgetApp {
         }
     }
 
-    editIncome() {
+    renderIncomeList() {
+        const container = document.getElementById('incomeList');
+        if (!container) return;
+
+        container.innerHTML = '';
+
+        Object.entries(this.data.monthlyBudget.income).forEach(([category, amount]) => {
+            const item = document.createElement('div');
+            item.className = 'income-item';
+            item.innerHTML = `
+                <span class="income-name">${category}</span>
+                <span class="income-amount">${this.formatCurrency(amount)}</span>
+                <div class="income-actions">
+                    <button class="btn btn--secondary btn--sm" onclick="app.showIncomeEditForm('${category}')">✏️</button>
+                    <button class="btn btn--secondary btn--sm" onclick="app.deleteIncome('${category}')">🗑️</button>
+                </div>
+            `;
+            container.appendChild(item);
+        });
+    }
+
+    showIncomeEditForm(category) {
+        const categoryInput = document.getElementById('incomeCategory');
+        const amountInput = document.getElementById('incomeAmount');
+        const originalInput = document.getElementById('incomeOriginalCategory');
+        const header = document.querySelector('#incomeModal .modal-header h3');
+
+        if (category) {
+            categoryInput.value = category;
+            amountInput.value = this.data.monthlyBudget.income[category];
+            originalInput.value = category;
+            if (header) header.textContent = 'Редактировать доход';
+        } else {
+            categoryInput.value = '';
+            amountInput.value = '';
+            originalInput.value = '';
+            if (header) header.textContent = 'Добавить доход';
+        }
+
+        this.hideModal('incomeListModal');
         this.showModal('incomeModal');
+    }
+
+    deleteIncome(category) {
+        if (!confirm('Удалить доход?')) return;
+        delete this.data.monthlyBudget.income[category];
+        this.saveData();
+        this.updateStats();
+        if (this.currentSection === 'analytics') {
+            this.renderAnalytics();
+        }
+        this.renderIncomeList();
+    }
+
+    editIncome() {
+        this.renderIncomeList();
+        this.showModal('incomeListModal');
     }
 
     editExpenses() {
@@ -1160,19 +1242,26 @@ class BudgetApp {
 
         const category = document.getElementById('incomeCategory').value.trim();
         const amount = parseFloat(document.getElementById('incomeAmount').value);
+        const original = document.getElementById('incomeOriginalCategory').value;
 
         if (!category || isNaN(amount)) {
             this.showNotification('Пожалуйста, заполните все поля');
             return;
         }
 
+        if (original && original !== category) {
+            delete this.data.monthlyBudget.income[original];
+        }
         this.data.monthlyBudget.income[category] = amount;
+        document.getElementById('incomeOriginalCategory').value = '';
         this.saveData();
         this.updateStats();
         if (this.currentSection === 'analytics') {
             this.renderAnalytics();
         }
         this.hideModal('incomeModal');
+        this.showModal('incomeListModal');
+        this.renderIncomeList();
     }
 
     handleExpenseSubmit(e) {

--- a/index.html
+++ b/index.html
@@ -407,6 +407,23 @@
         </div>
     </div>
 
+    <!-- Income List Modal -->
+    <div id="incomeListModal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Доходы</h3>
+                <button class="modal-close" id="closeIncomeListModal">×</button>
+            </div>
+            <div class="modal-body">
+                <div id="incomeList"></div>
+                <div class="modal-actions">
+                    <button type="button" class="btn btn--secondary" id="cancelIncomeList">Закрыть</button>
+                    <button type="button" class="btn btn--primary" id="addIncome">+ Добавить</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Edit Income Modal -->
     <div id="incomeModal" class="modal hidden">
         <div class="modal-content">
@@ -416,6 +433,7 @@
             </div>
             <div class="modal-body">
                 <form id="incomeForm">
+                    <input type="hidden" id="incomeOriginalCategory">
                     <div class="form-group">
                         <label class="form-label">Категория</label>
                         <input type="text" class="form-control" id="incomeCategory" placeholder="Например: Зарплата">


### PR DESCRIPTION
## Summary
- add income list modal with edit/delete controls
- support editing existing incomes via shared form
- refresh statistics after income updates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a462d486fc832298d1a753fde85501